### PR TITLE
Renamed Chat Panel Header to Shoutbox

### DIFF
--- a/widgets/views/chatframe.php
+++ b/widgets/views/chatframe.php
@@ -1,7 +1,7 @@
 <?php use yii\helpers\Url; ?>
 <div class="panel">
   <div class="panel-heading">
-    <?=Yii::t('HumhubChatModule.base', '<strong>Community</strong> Chat'); ?>
+    <?=Yii::t('HumhubChatModule.base', '<strong>Community</strong> Shoutbox'); ?>
   </div>
   <div class="panel-body">
     <div id="chatContainer">


### PR DESCRIPTION
I renamed the Chat Panel Header to Shoutbox. It makes more sense to rename Chat to Shoutbox, because it is more of a Shoutbox as a Chat :)